### PR TITLE
Add ECS framework skeleton and rendering stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 *Lightweight* and simple 3D java engine.
 
 Latest version: 0.1.0
+
+## Features
+- Basic ECS (Entity Component System) framework
+- Placeholders for deferred rendering and PBR materials

--- a/src/main/java/org/engine/vengine/ecs/Component.java
+++ b/src/main/java/org/engine/vengine/ecs/Component.java
@@ -1,0 +1,17 @@
+package org.engine.vengine.ecs;
+
+public abstract class Component {
+    private GameObject gameObject;
+
+    void setGameObject(GameObject obj) {
+        this.gameObject = obj;
+    }
+
+    public GameObject getGameObject() {
+        return gameObject;
+    }
+
+    public void start() {}
+
+    public void update(float deltaTime) {}
+}

--- a/src/main/java/org/engine/vengine/ecs/GameObject.java
+++ b/src/main/java/org/engine/vengine/ecs/GameObject.java
@@ -1,0 +1,39 @@
+package org.engine.vengine.ecs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GameObject {
+    private final List<Component> components = new ArrayList<>();
+    private final Transform transform = new Transform();
+
+    public GameObject() {
+        addComponent(transform);
+    }
+
+    public <T extends Component> T addComponent(T component) {
+        component.setGameObject(this);
+        components.add(component);
+        component.start();
+        return component;
+    }
+
+    public <T extends Component> T getComponent(Class<T> type) {
+        for (Component c : components) {
+            if (type.isInstance(c)) {
+                return type.cast(c);
+            }
+        }
+        return null;
+    }
+
+    public void update(float deltaTime) {
+        for (Component c : components) {
+            c.update(deltaTime);
+        }
+    }
+
+    public Transform getTransform() {
+        return transform;
+    }
+}

--- a/src/main/java/org/engine/vengine/ecs/MeshRenderer.java
+++ b/src/main/java/org/engine/vengine/ecs/MeshRenderer.java
@@ -1,0 +1,22 @@
+package org.engine.vengine.ecs;
+
+import org.engine.vengine.render.Renderer;
+
+/**
+ * Simple component that delegates drawing to the engine renderer.
+ * This is only a placeholder and does not implement a full feature set.
+ */
+public class MeshRenderer extends Component {
+    private Renderer renderer;
+
+    public MeshRenderer(Renderer renderer) {
+        this.renderer = renderer;
+    }
+
+    @Override
+    public void update(float deltaTime) {
+        if (renderer != null) {
+            renderer.render();
+        }
+    }
+}

--- a/src/main/java/org/engine/vengine/ecs/Transform.java
+++ b/src/main/java/org/engine/vengine/ecs/Transform.java
@@ -1,0 +1,13 @@
+package org.engine.vengine.ecs;
+
+import org.joml.Vector3f;
+
+public class Transform extends Component {
+    private final Vector3f position = new Vector3f();
+    private final Vector3f rotation = new Vector3f();
+    private final Vector3f scale = new Vector3f(1,1,1);
+
+    public Vector3f getPosition() { return position; }
+    public Vector3f getRotation() { return rotation; }
+    public Vector3f getScale() { return scale; }
+}

--- a/src/main/java/org/engine/vengine/render/deferred/DeferredRenderer.java
+++ b/src/main/java/org/engine/vengine/render/deferred/DeferredRenderer.java
@@ -1,0 +1,23 @@
+package org.engine.vengine.render.deferred;
+
+import org.engine.vengine.core.Window;
+
+/**
+ * Placeholder for a deferred rendering pipeline.
+ * This implementation is minimal and intended for future expansion.
+ */
+public class DeferredRenderer {
+    private final Window window;
+
+    public DeferredRenderer(Window window) {
+        this.window = window;
+    }
+
+    public void init() {
+        // TODO: setup G-Buffer and load PBR shaders
+    }
+
+    public void render() {
+        // TODO: implement geometry and lighting passes
+    }
+}

--- a/src/main/java/org/engine/vengine/render/materials/pbr/PBRMaterial.java
+++ b/src/main/java/org/engine/vengine/render/materials/pbr/PBRMaterial.java
@@ -1,0 +1,12 @@
+package org.engine.vengine.render.materials.pbr;
+
+import org.engine.vengine.render.materials.Material;
+
+/**
+ * Minimal placeholder for a physically based rendering material.
+ */
+public class PBRMaterial extends Material {
+    public PBRMaterial() {
+        super(null); // requires PBR shaders to be provided in the future
+    }
+}


### PR DESCRIPTION
## Summary
- implement simple ECS with `GameObject`, `Component`, and `Transform`
- add a `MeshRenderer` component that hooks into the existing renderer
- introduce placeholder classes for deferred rendering and PBR materials
- update README with new feature list

## Testing
- `mvn test` *(fails: unable to resolve LWJGL dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68891227887c832b96a92eafddddec55